### PR TITLE
feat: increase Notizen edit mode height

### DIFF
--- a/src/app/ideas/idea-detail/idea-detail.ts
+++ b/src/app/ideas/idea-detail/idea-detail.ts
@@ -118,7 +118,7 @@ import { LucideFileText, LucideSquareCheck } from '@lucide/angular';
           <svg lucideFileText sectionIcon class="text-[var(--color-text-muted)] shrink-0" [size]="16"></svg>
           @if (editingDescription()) {
             <textarea
-              class="text-sm text-[var(--color-text-body)] leading-relaxed w-full bg-transparent border border-[var(--color-primary-solid)] rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] min-h-[120px] resize-none"
+              class="text-sm text-[var(--color-text-body)] leading-relaxed w-full bg-transparent border border-[var(--color-primary-solid)] rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] min-h-[180px] resize-none"
               [value]="draftDescription()"
               (input)="draftDescription.set($any($event.target).value)"
               (blur)="saveDescription()"

--- a/src/app/todos/todo-detail/todo-detail.ts
+++ b/src/app/todos/todo-detail/todo-detail.ts
@@ -121,7 +121,7 @@ import { LucideFileText, LucideSquareCheck } from '@lucide/angular';
           <svg lucideFileText sectionIcon class="text-[var(--color-text-muted)] shrink-0" [size]="16"></svg>
           @if (editingDescription()) {
             <textarea
-              class="text-sm text-[var(--color-text-body)] leading-relaxed w-full bg-transparent border border-[var(--color-primary-solid)] rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] min-h-[120px] resize-none"
+              class="text-sm text-[var(--color-text-body)] leading-relaxed w-full bg-transparent border border-[var(--color-primary-solid)] rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] min-h-[180px] resize-none"
               [value]="draftDescription()"
               (input)="draftDescription.set($any($event.target).value)"
               (blur)="saveDescription()"


### PR DESCRIPTION
This PR addresses user feedback that the vertical space for Notizen when in edit mode was too low. The textarea height has been increased by 60px (from 120px to 180px) in both idea-detail and todo-detail components to provide more comfortable editing space.

## Changes Made
- Increased `min-h-[120px]` to `min-h-[180px]` in idea-detail component textarea
- Increased `min-h-[120px]` to `min-h-[180px]` in todo-detail component textarea

## Testing
The changes are minimal and focused only on the height adjustment. The functionality remains the same, just with more vertical space for editing Notizen.

## Screenshots
(N/A - visual change that can be verified by opening the edit mode for Notizen in either ideas or todos)

## Related Issues
Addresses user feedback about insufficient vertical space for Notizen editing.