### PR TITLE
fix: skip rendering large diffs to prevent performance issues

### DIFF
--- a/src/app/bitbucket/pr-detail/pr-detail.spec.ts
+++ b/src/app/bitbucket/pr-detail/pr-detail.spec.ts
@@ -117,6 +117,22 @@ index 0000001..0000002 100644
 +const b = 3;
  const c = 4;`;
 
+function makeFileDiff(name: string, changedLines: number): string {
+  const oldLines = Array.from({ length: changedLines }, (_, i) => `-old${i}`).join('\n');
+  const newLines = Array.from({ length: changedLines }, (_, i) => `+new${i}`).join('\n');
+  return `diff --git a/${name} b/${name}
+index 0000001..0000002 100644
+--- a/${name}
++++ b/${name}
+@@ -1,${changedLines} +1,${changedLines} @@
+${oldLines}
+${newLines}`;
+}
+
+function makeManyFilesDiff(count: number): string {
+  return Array.from({ length: count }, (_, i) => makeFileDiff(`file${i}.ts`, 1)).join('\n');
+}
+
 describe('PrDetailComponent', () => {
   let fixture: ComponentFixture<PrDetailComponent>;
   const getTicketByKey = vi.fn();
@@ -403,5 +419,45 @@ describe('PrDetailComponent', () => {
 
     expect(fixture.nativeElement.textContent).toContain('Reviewer:');
     expect(fixture.nativeElement.textContent).toContain('Reviewer One');
+  });
+
+  it('shows too-many-files message when diff has 50+ files', async () => {
+    getTicketByKey.mockReturnValue(of(mockTicket));
+    getPullRequestDiff.mockReturnValue(of(makeManyFilesDiff(50)));
+    fixture = TestBed.createComponent(PrDetailComponent);
+    fixture.componentRef.setInput('pr', basePr);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const diffButton = Array.from<Element>(fixture.nativeElement.querySelectorAll('button')).find(
+      (b) => b.textContent!.includes('Änderungen'),
+    ) as HTMLButtonElement;
+    diffButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('50 geänderte Dateien');
+    expect(fixture.nativeElement.textContent).toContain('Performance-Probleme');
+    expect(fixture.nativeElement.querySelector('.overflow-x-auto')).toBeNull();
+  });
+
+  it('filters out large files and shows skipped file names', async () => {
+    getTicketByKey.mockReturnValue(of(mockTicket));
+    const diff = SAMPLE_DIFF + '\n' + makeFileDiff('package-lock.json', 800);
+    getPullRequestDiff.mockReturnValue(of(diff));
+    fixture = TestBed.createComponent(PrDetailComponent);
+    fixture.componentRef.setInput('pr', basePr);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const diffButton = Array.from<Element>(fixture.nativeElement.querySelectorAll('button')).find(
+      (b) => b.textContent!.includes('Änderungen'),
+    ) as HTMLButtonElement;
+    diffButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('package-lock.json');
+    expect(fixture.nativeElement.textContent).toContain('nicht als Diff angezeigt');
   });
 });

--- a/src/app/bitbucket/pr-detail/pr-detail.ts
+++ b/src/app/bitbucket/pr-detail/pr-detail.ts
@@ -43,6 +43,7 @@ import {
 } from '@lucide/angular';
 import * as Diff2Html from 'diff2html';
 import { Diff2HtmlUI } from 'diff2html/lib/ui/js/diff2html-ui-base';
+import type { DiffFile } from 'diff2html/lib/types';
 import { ColorSchemeType } from 'diff2html/lib/types';
 import hljs from 'highlight.js/lib/core';
 import typescript from 'highlight.js/lib/languages/typescript';
@@ -377,7 +378,31 @@ import plaintext from 'highlight.js/lib/languages/plaintext';
             </p>
           } @else if (diffFileCount() === 0) {
             <p class="text-sm text-[var(--color-text-muted)] italic">Keine Änderungen vorhanden.</p>
+          } @else if (tooManyFiles()) {
+            <div class="space-y-2">
+              <p class="text-sm text-[var(--color-text-muted)] italic">
+                Dieser PR enthält {{ diffFileCount() }} geänderte Dateien. Die Diff-Ansicht wird bei
+                mehr als 50 Dateien nicht angezeigt, um Performance-Probleme zu
+                vermeiden.
+              </p>
+            </div>
           } @else {
+            @if (skippedFiles().length > 0) {
+              <div
+                class="mb-3 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-3"
+              >
+                <p class="text-sm text-[var(--color-text-muted)] mb-2">
+                  {{ skippedFiles().length === 1 ? 'Eine Datei wird' : skippedFiles().length + ' Dateien werden' }}
+                  nicht als Diff angezeigt, da sie zu viele Änderungen
+                  {{ skippedFiles().length === 1 ? 'enthält' : 'enthalten' }}:
+                </p>
+                <ul class="list-none space-y-0.5">
+                  @for (file of skippedFiles(); track file) {
+                    <li class="font-mono text-xs text-[var(--color-text-body)]">{{ file }}</li>
+                  }
+                </ul>
+              </div>
+            }
             <div
               #diffContainer
               class="overflow-x-auto rounded border border-[var(--color-border-subtle)]"
@@ -484,6 +509,9 @@ export class PrDetailComponent {
     { initialValue: 'loading' as const },
   );
 
+  private static readonly MAX_CHANGED_LINES = 1500;
+  private static readonly MAX_FILES = 50;
+
   private readonly diffParsed = computed(() => {
     const data = this.diffData();
     if (data === 'loading' || data === 'error') return null;
@@ -491,6 +519,28 @@ export class PrDetailComponent {
   });
 
   readonly diffFileCount = computed(() => this.diffParsed()?.length ?? 0);
+
+  readonly tooManyFiles = computed(() => this.diffFileCount() >= PrDetailComponent.MAX_FILES);
+
+  private readonly diffFiltered = computed((): {
+    renderable: DiffFile[];
+    skipped: string[];
+  } | null => {
+    const files = this.diffParsed();
+    if (!files) return null;
+    const renderable: DiffFile[] = [];
+    const skipped: string[] = [];
+    for (const file of files) {
+      if (file.addedLines + file.deletedLines > PrDetailComponent.MAX_CHANGED_LINES) {
+        skipped.push(file.newName || file.oldName);
+      } else {
+        renderable.push(file);
+      }
+    }
+    return { renderable, skipped };
+  });
+
+  readonly skippedFiles = computed(() => this.diffFiltered()?.skipped ?? []);
 
   private readonly dataReady = computed(() => {
     const diff = this.diffData();
@@ -505,12 +555,14 @@ export class PrDetailComponent {
   private renderEffect = effect(() => {
     const container = this.diffContainer();
     if (!container) return;
-    const data = this.diffData();
-    if (data === 'loading' || data === 'error') return;
+    const filtered = this.diffFiltered();
+    if (!filtered || this.tooManyFiles()) return;
+    const files = filtered.renderable;
+    if (files.length === 0) return;
     setTimeout(() => {
       const ui = new Diff2HtmlUI(
         container.nativeElement,
-        data,
+        files,
         {
           outputFormat: 'line-by-line',
           drawFileList: false,


### PR DESCRIPTION
## Summary

Fixes #19 — large PRs with many files or huge individual diffs (e.g. `package-lock.json`) caused Orbit to become unresponsive.

- **50+ files**: diff section shows an info message instead of rendering, explaining the limit
- **Individual files with >1500 changed lines**: filtered out of the rendered diff, listed by name with an explanation in German
- Passes filtered `DiffFile[]` directly to `Diff2HtmlUI` instead of reconstructing raw diff strings

## Test plan

- [x] Build passes (`ng build`)
- [x] All 351 tests pass (`ng test --no-watch`)
- [x] New test: verifies too-many-files message appears for 50+ file diffs
- [x] New test: verifies large file names are shown as skipped
- [ ] Manual: open a PR with a large `package-lock.json` change — file should be listed as skipped
- [ ] Manual: open a PR with 50+ changed files — diff section shows info message

🤖 Generated with [Claude Code](https://claude.com/claude-code)