### PR TITLE
Quick Capture UX/UI verbessern (#8)

### DIFF
--- a/docs/superpowers/plans/2026-04-14-quick-capture-improvements.md
+++ b/docs/superpowers/plans/2026-04-14-quick-capture-improvements.md
@@ -1,0 +1,358 @@
+# Quick Capture UX/UI Improvements — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve Quick Capture discoverability and usability by adding keyboard hints, a visible trigger button in the rail, and a Quick Capture hint in the workbench empty state.
+
+**Architecture:** Three focused changes to existing components. No new files, no new services. The rail button emits an event that `app.ts` wires to the existing `overlayOpen` signal.
+
+**Tech Stack:** Angular 21 (signals, zoneless), Tailwind CSS, Lucide icons, Vitest
+
+---
+
+### Task 1: Add keyboard hints to Quick Capture modal
+
+**Files:**
+- Modify: `src/app/shared/quick-capture/quick-capture.ts:44-72` (template, after the toggle buttons div)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/shared/quick-capture/quick-capture.spec.ts`:
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { QuickCaptureComponent } from './quick-capture';
+
+const mockMatchMedia = () => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+};
+
+describe('QuickCaptureComponent', () => {
+  beforeEach(async () => {
+    mockMatchMedia();
+    await TestBed.configureTestingModule({
+      imports: [QuickCaptureComponent],
+    }).compileComponents();
+  });
+
+  it('should show keyboard hints when open', () => {
+    const fixture = TestBed.createComponent(QuickCaptureComponent);
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+    const hints = fixture.nativeElement.querySelector('[data-testid="keyboard-hints"]');
+    expect(hints).toBeTruthy();
+    expect(hints.textContent).toContain('Speichern');
+    expect(hints.textContent).toContain('Abbrechen');
+    expect(hints.textContent).toContain('Wechseln');
+  });
+
+  it('should not render anything when closed', () => {
+    const fixture = TestBed.createComponent(QuickCaptureComponent);
+    fixture.componentRef.setInput('open', false);
+    fixture.detectChanges();
+    const dialog = fixture.nativeElement.querySelector('[role="dialog"]');
+    expect(dialog).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: FAIL — "keyboard-hints" element not found
+
+- [ ] **Step 3: Add keyboard hints to the template**
+
+In `src/app/shared/quick-capture/quick-capture.ts`, add after the closing `</div>` of the toggle button group (after line 72):
+
+```html
+          <div
+            data-testid="keyboard-hints"
+            class="text-xs text-[var(--color-text-muted)] text-center mt-2"
+            aria-hidden="true"
+          >
+            ↵ Speichern · Esc Abbrechen · Tab Wechseln
+          </div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/shared/quick-capture/quick-capture.ts src/app/shared/quick-capture/quick-capture.spec.ts
+git commit -m "feat: add keyboard hints to quick capture modal (#8)"
+```
+
+---
+
+### Task 2: Add Quick Capture button to app rail
+
+**Files:**
+- Modify: `src/app/shared/app-rail/app-rail.ts:1-101` (import LucidePlus, add button to template, add output)
+- Modify: `src/app/shared/app-rail/app-rail.spec.ts` (add tests for new button)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `describe` block in `src/app/shared/app-rail/app-rail.spec.ts`:
+
+```typescript
+  it('should render a quick capture button', () => {
+    const fixture = TestBed.createComponent(AppRailComponent);
+    fixture.componentRef.setInput('activeView', 'arbeit');
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('[aria-label="Quick Capture"]');
+    expect(button).toBeTruthy();
+  });
+
+  it('should show shortcut hint on quick capture button', () => {
+    const fixture = TestBed.createComponent(AppRailComponent);
+    fixture.componentRef.setInput('activeView', 'arbeit');
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('[aria-label="Quick Capture"]');
+    const text = button.textContent;
+    expect(text).toMatch(/[⌘Ctrl]\+?K/);
+  });
+
+  it('should emit quickCapture on button click', () => {
+    const fixture = TestBed.createComponent(AppRailComponent);
+    fixture.componentRef.setInput('activeView', 'arbeit');
+    fixture.detectChanges();
+    const spy = vi.fn();
+    fixture.componentInstance.quickCapture.subscribe(spy);
+    const button = fixture.nativeElement.querySelector('[aria-label="Quick Capture"]');
+    button.click();
+    expect(spy).toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: FAIL — quickCapture property does not exist, button not found
+
+- [ ] **Step 3: Add the Quick Capture button to app-rail**
+
+In `src/app/shared/app-rail/app-rail.ts`:
+
+Add `LucidePlus` to the import from `@lucide/angular`:
+```typescript
+import { LucideZap, LucideActivity, LucideBookOpen, LucideSettings, LucidePlus } from '@lucide/angular';
+```
+
+Add `LucidePlus` to the component `imports` array.
+
+Add a `quickCapture` output and a `shortcutLabel` property:
+```typescript
+  quickCapture = output<void>();
+
+  protected readonly shortcutLabel = navigator.platform?.includes('Mac') ? '⌘K' : 'Ctrl+K';
+```
+
+In the template, add the button between the logo `div` and the `<nav>` element:
+
+```html
+    <button
+      type="button"
+      class="w-[52px] h-12 flex flex-col items-center justify-center rounded-lg text-[var(--color-primary-text)] hover:bg-[var(--color-bg-surface)] transition-colors duration-100 mt-2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400"
+      aria-label="Quick Capture"
+      (click)="quickCapture.emit()"
+    >
+      <svg lucidePlus [size]="20" [strokeWidth]="1.5"></svg>
+      <span class="text-[10px] font-medium leading-tight mt-0.5">{{ shortcutLabel }}</span>
+    </button>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/shared/app-rail/app-rail.ts src/app/shared/app-rail/app-rail.spec.ts
+git commit -m "feat: add quick capture button to app rail (#8)"
+```
+
+---
+
+### Task 3: Wire rail button to Quick Capture overlay
+
+**Files:**
+- Modify: `src/app/app.html:9` (add quickCapture event binding)
+- Modify: `src/app/app.spec.ts` (add test for wiring)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe` block in `src/app/app.spec.ts`:
+
+```typescript
+  it('should open quick capture when rail emits quickCapture', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const rail = fixture.nativeElement.querySelector('app-rail');
+    rail.dispatchEvent(new Event('quickCapture'));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.overlayOpen()).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: FAIL — overlayOpen is still false
+
+- [ ] **Step 3: Add event binding in app.html**
+
+In `src/app/app.html`, modify the `<app-rail>` line:
+
+```html
+    <app-rail [activeView]="routerSync.activeView()" (viewChange)="onViewChange($event)" (quickCapture)="overlayOpen.set(true)" />
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/app.html src/app/app.spec.ts
+git commit -m "feat: wire rail quick capture button to overlay (#8)"
+```
+
+---
+
+### Task 4: Add Quick Capture hint to workbench empty state
+
+**Files:**
+- Modify: `src/app/shared/workbench/workbench.html:24-27` (add hint line)
+- Modify: `src/app/shared/workbench/workbench.ts` (add shortcutLabel property)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/shared/workbench/workbench.spec.ts`:
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { WorkbenchComponent } from './workbench';
+import { WorkspaceService } from '../workspace.service';
+import { signal } from '@angular/core';
+
+const mockMatchMedia = () => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+};
+
+describe('WorkbenchComponent', () => {
+  beforeEach(async () => {
+    mockMatchMedia();
+    await TestBed.configureTestingModule({
+      imports: [WorkbenchComponent],
+      providers: [
+        {
+          provide: WorkspaceService,
+          useValue: {
+            selectedItem: signal(null),
+            reflectionSelected: signal(false),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should show quick capture hint in empty state', () => {
+    const fixture = TestBed.createComponent(WorkbenchComponent);
+    fixture.detectChanges();
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Quick Capture');
+    expect(text).toMatch(/[⌘Ctrl]\+?K/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: FAIL — "Quick Capture" not found in text
+
+- [ ] **Step 3: Add shortcutLabel to workbench component**
+
+In `src/app/shared/workbench/workbench.ts`, add inside the class:
+
+```typescript
+  protected readonly shortcutLabel = navigator.platform?.includes('Mac') ? '⌘K' : 'Ctrl+K';
+```
+
+- [ ] **Step 4: Add the hint line to workbench.html**
+
+In `src/app/shared/workbench/workbench.html`, after the existing `<p>` tag (line 27), add:
+
+```html
+          <p class="text-sm text-[var(--color-text-muted)] mt-2">
+            Oder drücke <kbd class="px-1.5 py-0.5 rounded bg-[var(--color-bg-surface)] border border-[var(--color-border-subtle)] text-xs font-mono">{{ shortcutLabel }}</kbd> für Quick Capture
+          </p>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx ng test --no-watch 2>&1 | tail -20`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/shared/workbench/workbench.ts src/app/shared/workbench/workbench.html src/app/shared/workbench/workbench.spec.ts
+git commit -m "feat: add quick capture hint to workbench empty state (#8)"
+```
+
+---
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npx ng test --no-watch`
+Expected: All tests pass
+
+- [ ] **Step 2: Run build**
+
+Run: `npx ng build`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 3: Visual verification**
+
+Start the dev server with `npx ng serve` and verify in browser:
+1. Quick Capture button visible in rail, below logo, showing ⌘K/Ctrl+K
+2. Clicking the button opens Quick Capture modal
+3. Modal shows keyboard hints below toggle buttons
+4. Workbench empty state (no item selected) shows Quick Capture hint with kbd styling
+5. Both light and dark mode work correctly

--- a/docs/superpowers/specs/2026-04-14-quick-capture-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-14-quick-capture-improvements-design.md
@@ -1,0 +1,74 @@
+# Quick Capture UX/UI Improvements
+
+**Issue:** #8 — Quick Capture UX/UI verbessern  
+**Date:** 2026-04-14  
+**Branch:** feature/quick-capture-improvements
+
+## Problem
+
+Quick Capture has two UX gaps:
+1. No visible save/cancel affordance — users don't know how to interact with the modal
+2. The feature is undiscoverable — no visual indicator that it exists, only an invisible keyboard shortcut (Cmd+K / Ctrl+K)
+
+## Design Decisions
+
+- Keep Quick Capture as minimal as possible — no additional form fields, no extra UI complexity
+- Keyboard hints instead of clickable buttons (target audience is keyboard-focused developers)
+- Direct changes to existing components, no new component files
+
+## Changes
+
+### 1. Keyboard Hints in Quick Capture Modal
+
+Add a hint line below the mode toggle (Aufgabe/Idee buttons):
+
+```
+↵ Speichern · Esc Abbrechen · Tab Wechseln
+```
+
+- Purely informational text, no clickable elements
+- Styled with `text-xs`, `text-[var(--color-text-muted)]`, centered, `mt-2`
+- Documents all three keyboard interactions (Enter, Escape, Tab) that are currently undiscoverable
+
+**File:** `src/app/shared/quick-capture/quick-capture.ts`
+
+### 2. Quick Capture Button in App Rail
+
+Add a button directly below the logo area, above the navigation items.
+
+- Same sizing as nav buttons: `w-[52px] h-12`
+- Lucide `LucidePlus` icon in `violet-400`
+- Label below icon: `⌘K` on macOS, `Ctrl+K` on other platforms (same `text-[10px]` style as view labels)
+- Hover state matching inactive nav buttons: `hover:bg-stone-800`, `hover:text-stone-200`
+- Separated from navigation by the existing logo area border-bottom — no extra separator needed
+- Emits a new `quickCapture` output event, wired through `app.ts` to set `overlayOpen`
+- Platform detection via `navigator.platform` for shortcut label
+
+**Files:** `src/app/shared/app-rail/app-rail.ts`, `src/app/app.html`, `src/app/app.ts`
+
+### 3. Empty State Hint in Workbench
+
+Extend the existing workbench empty state ("Bereit loszulegen?") with a Quick Capture hint.
+
+Add below the existing paragraph:
+
+```
+Oder drücke ⌘K für Quick Capture
+```
+
+- Same style as existing text: `text-sm`, `text-[var(--color-text-muted)]`
+- Shortcut rendered as `<kbd>` element (subtle visual distinction)
+- Platform-aware: `⌘K` on macOS, `Ctrl+K` on other platforms
+
+**File:** `src/app/shared/workbench/workbench.ts` (or `.html`)
+
+## Scope
+
+Three focused changes to existing components. No new files, no new services, no architectural changes.
+
+## Out of Scope
+
+- Save confirmation / feedback after capture
+- Multi-capture (staying open after save)
+- Additional form fields (description, urgency, tags)
+- Hints in other views (Builds, Logbuch)

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -6,7 +6,7 @@
     <app-pomodoro-progress-bar />
   }
   <div class="flex h-screen overflow-hidden">
-    <app-rail [activeView]="routerSync.activeView()" (viewChange)="onViewChange($event)" />
+    <app-rail [activeView]="routerSync.activeView()" (viewChange)="onViewChange($event)" (quickCapture)="overlayOpen.set(true)" />
 
     <router-outlet />
   </div>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -6,7 +6,11 @@
     <app-pomodoro-progress-bar />
   }
   <div class="flex h-screen overflow-hidden">
-    <app-rail [activeView]="routerSync.activeView()" (viewChange)="onViewChange($event)" (quickCapture)="overlayOpen.set(true)" />
+    <app-rail
+      [activeView]="routerSync.activeView()"
+      (viewChange)="onViewChange($event)"
+      (quickCapture)="overlayOpen.set(true)"
+    />
 
     <router-outlet />
   </div>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -62,4 +62,13 @@ describe('App', () => {
     const rail = fixture.nativeElement.querySelector('app-rail');
     expect(rail).toBeTruthy();
   });
+
+  it('should open quick capture when rail emits quickCapture', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const rail = fixture.nativeElement.querySelector('app-rail');
+    rail.dispatchEvent(new Event('quickCapture'));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.overlayOpen()).toBe(true);
+  });
 });

--- a/src/app/bitbucket/pr-detail/pr-detail.ts
+++ b/src/app/bitbucket/pr-detail/pr-detail.ts
@@ -382,8 +382,7 @@ import plaintext from 'highlight.js/lib/languages/plaintext';
             <div class="space-y-2">
               <p class="text-sm text-[var(--color-text-muted)] italic">
                 Dieser PR enthält {{ diffFileCount() }} geänderte Dateien. Die Diff-Ansicht wird bei
-                mehr als 50 Dateien nicht angezeigt, um Performance-Probleme zu
-                vermeiden.
+                mehr als 50 Dateien nicht angezeigt, um Performance-Probleme zu vermeiden.
               </p>
             </div>
           } @else {
@@ -392,7 +391,11 @@ import plaintext from 'highlight.js/lib/languages/plaintext';
                 class="mb-3 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-3"
               >
                 <p class="text-sm text-[var(--color-text-muted)] mb-2">
-                  {{ skippedFiles().length === 1 ? 'Eine Datei wird' : skippedFiles().length + ' Dateien werden' }}
+                  {{
+                    skippedFiles().length === 1
+                      ? 'Eine Datei wird'
+                      : skippedFiles().length + ' Dateien werden'
+                  }}
                   nicht als Diff angezeigt, da sie zu viele Änderungen
                   {{ skippedFiles().length === 1 ? 'enthält' : 'enthalten' }}:
                 </p>
@@ -522,23 +525,25 @@ export class PrDetailComponent {
 
   readonly tooManyFiles = computed(() => this.diffFileCount() >= PrDetailComponent.MAX_FILES);
 
-  private readonly diffFiltered = computed((): {
-    renderable: DiffFile[];
-    skipped: string[];
-  } | null => {
-    const files = this.diffParsed();
-    if (!files) return null;
-    const renderable: DiffFile[] = [];
-    const skipped: string[] = [];
-    for (const file of files) {
-      if (file.addedLines + file.deletedLines > PrDetailComponent.MAX_CHANGED_LINES) {
-        skipped.push(file.newName || file.oldName);
-      } else {
-        renderable.push(file);
+  private readonly diffFiltered = computed(
+    (): {
+      renderable: DiffFile[];
+      skipped: string[];
+    } | null => {
+      const files = this.diffParsed();
+      if (!files) return null;
+      const renderable: DiffFile[] = [];
+      const skipped: string[] = [];
+      for (const file of files) {
+        if (file.addedLines + file.deletedLines > PrDetailComponent.MAX_CHANGED_LINES) {
+          skipped.push(file.newName || file.oldName);
+        } else {
+          renderable.push(file);
+        }
       }
-    }
-    return { renderable, skipped };
-  });
+      return { renderable, skipped };
+    },
+  );
 
   readonly skippedFiles = computed(() => this.diffFiltered()?.skipped ?? []);
 

--- a/src/app/ideas/idea-inline-input/idea-inline-input.ts
+++ b/src/app/ideas/idea-inline-input/idea-inline-input.ts
@@ -1,4 +1,3 @@
-
 import { ChangeDetectionStrategy, Component, ElementRef, output, viewChild } from '@angular/core';
 
 @Component({

--- a/src/app/jira/jira.service.spec.ts
+++ b/src/app/jira/jira.service.spec.ts
@@ -408,7 +408,10 @@ describe('JiraService', () => {
   });
 
   it('uses cached user display names from localStorage instead of making API calls', () => {
-    localStorage.setItem('jira.userDisplayNameCache', JSON.stringify({ cacheduser: 'Cached User' }));
+    localStorage.setItem(
+      'jira.userDisplayNameCache',
+      JSON.stringify({ cacheduser: 'Cached User' }),
+    );
 
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({

--- a/src/app/shared/app-rail/app-rail.spec.ts
+++ b/src/app/shared/app-rail/app-rail.spec.ts
@@ -45,7 +45,7 @@ describe('AppRailComponent', () => {
     const fixture = TestBed.createComponent(AppRailComponent);
     fixture.componentRef.setInput('activeView', 'arbeit');
     fixture.detectChanges();
-    const buttons = fixture.nativeElement.querySelectorAll('button');
+    const buttons = fixture.nativeElement.querySelectorAll('nav button');
     expect(buttons[0].getAttribute('aria-current')).toBe('page');
     expect(buttons[1].getAttribute('aria-current')).toBeNull();
     expect(buttons[2].getAttribute('aria-current')).toBeNull();
@@ -57,7 +57,7 @@ describe('AppRailComponent', () => {
     fixture.detectChanges();
     const spy = vi.fn();
     fixture.componentInstance.viewChange.subscribe(spy);
-    const buttons = fixture.nativeElement.querySelectorAll('button');
+    const buttons = fixture.nativeElement.querySelectorAll('nav button');
     buttons[2].click();
     expect(spy).toHaveBeenCalledWith('logbuch');
   });
@@ -66,7 +66,7 @@ describe('AppRailComponent', () => {
     const fixture = TestBed.createComponent(AppRailComponent);
     fixture.componentRef.setInput('activeView', 'arbeit');
     fixture.detectChanges();
-    const buttons = fixture.nativeElement.querySelectorAll('button');
+    const buttons = fixture.nativeElement.querySelectorAll('nav button');
     buttons[0].focus();
     buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
     expect(document.activeElement).toBe(buttons[1]);
@@ -78,5 +78,33 @@ describe('AppRailComponent', () => {
     fixture.detectChanges();
     const nav = fixture.nativeElement.querySelector('nav');
     expect(nav.getAttribute('aria-label')).toBe('Hauptnavigation');
+  });
+
+  it('should render a quick capture button', () => {
+    const fixture = TestBed.createComponent(AppRailComponent);
+    fixture.componentRef.setInput('activeView', 'arbeit');
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('[aria-label="Quick Capture"]');
+    expect(button).toBeTruthy();
+  });
+
+  it('should show shortcut hint on quick capture button', () => {
+    const fixture = TestBed.createComponent(AppRailComponent);
+    fixture.componentRef.setInput('activeView', 'arbeit');
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('[aria-label="Quick Capture"]');
+    const text = button.textContent;
+    expect(text).toMatch(/[⌘Ctrl]\+?K/);
+  });
+
+  it('should emit quickCapture on button click', () => {
+    const fixture = TestBed.createComponent(AppRailComponent);
+    fixture.componentRef.setInput('activeView', 'arbeit');
+    fixture.detectChanges();
+    const spy = vi.fn();
+    fixture.componentInstance.quickCapture.subscribe(spy);
+    const button = fixture.nativeElement.querySelector('[aria-label="Quick Capture"]');
+    button.click();
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/app-rail/app-rail.ts
+++ b/src/app/shared/app-rail/app-rail.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
-import { LucideZap, LucideActivity, LucideBookOpen, LucideSettings } from '@lucide/angular';
+import { LucideZap, LucideActivity, LucideBookOpen, LucideSettings, LucidePlus } from '@lucide/angular';
 
 interface OrbitView {
   id: string;
@@ -15,7 +15,7 @@ const VIEWS: OrbitView[] = [
 @Component({
   selector: 'app-rail',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [LucideZap, LucideActivity, LucideBookOpen, LucideSettings],
+  imports: [LucideZap, LucideActivity, LucideBookOpen, LucideSettings, LucidePlus],
   host: {
     class: 'w-16 shrink-0 bg-[var(--color-rail-bg)] flex flex-col items-center',
   },
@@ -30,6 +30,16 @@ const VIEWS: OrbitView[] = [
         <div class="w-3 h-3 rounded-full border-2 border-white"></div>
       </div>
     </div>
+
+    <button
+      type="button"
+      class="w-[52px] h-12 flex flex-col items-center justify-center rounded-lg text-[var(--color-primary-text)] hover:bg-[var(--color-bg-surface)] transition-colors duration-100 mt-2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400"
+      aria-label="Quick Capture"
+      (click)="quickCapture.emit()"
+    >
+      <svg lucidePlus [size]="20" [strokeWidth]="1.5"></svg>
+      <span class="text-[10px] font-medium leading-tight mt-0.5">{{ shortcutLabel }}</span>
+    </button>
 
     <nav aria-label="Hauptnavigation" class="flex flex-col items-center gap-1 mt-2">
       @for (view of views; track view.id) {
@@ -81,7 +91,9 @@ const VIEWS: OrbitView[] = [
 export class AppRailComponent {
   activeView = input.required<string>();
   viewChange = output<string>();
+  quickCapture = output<void>();
 
+  protected readonly shortcutLabel = navigator.platform?.includes('Mac') ? '⌘K' : 'Ctrl+K';
   protected readonly views = VIEWS;
 
   onKeydown(event: KeyboardEvent): void {

--- a/src/app/shared/app-rail/app-rail.ts
+++ b/src/app/shared/app-rail/app-rail.ts
@@ -1,5 +1,11 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
-import { LucideZap, LucideActivity, LucideBookOpen, LucideSettings, LucidePlus } from '@lucide/angular';
+import {
+  LucideZap,
+  LucideActivity,
+  LucideBookOpen,
+  LucideSettings,
+  LucidePlus,
+} from '@lucide/angular';
 
 interface OrbitView {
   id: string;

--- a/src/app/shared/app-rail/app-rail.ts
+++ b/src/app/shared/app-rail/app-rail.ts
@@ -39,7 +39,7 @@ const VIEWS: OrbitView[] = [
 
     <button
       type="button"
-      class="w-[52px] h-12 flex flex-col items-center justify-center rounded-lg text-[var(--color-primary-text)] hover:bg-[var(--color-bg-surface)] transition-colors duration-100 mt-2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400"
+      class="w-[52px] h-12 flex flex-col items-center justify-center rounded-lg text-stone-400 hover:text-stone-200 hover:bg-stone-800 transition-colors duration-100 mt-2 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-400"
       aria-label="Quick Capture"
       (click)="quickCapture.emit()"
     >

--- a/src/app/shared/focus.service.spec.ts
+++ b/src/app/shared/focus.service.spec.ts
@@ -78,7 +78,7 @@ describe('FocusService', () => {
             tickets: ticketsSignal,
             pullRequests: pullRequestsSignal,
             ticketsLoading: ticketsLoadingSignal,
-            pullRequestsLoading: pullRequestsLoadingSignal
+            pullRequestsLoading: pullRequestsLoadingSignal,
           },
         },
       ],

--- a/src/app/shared/quick-capture/quick-capture.spec.ts
+++ b/src/app/shared/quick-capture/quick-capture.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { QuickCaptureComponent } from './quick-capture';
+
+const mockMatchMedia = () => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+};
+
+describe('QuickCaptureComponent', () => {
+  beforeEach(async () => {
+    mockMatchMedia();
+    await TestBed.configureTestingModule({
+      imports: [QuickCaptureComponent],
+    }).compileComponents();
+  });
+
+  it('should show keyboard hints when open', () => {
+    const fixture = TestBed.createComponent(QuickCaptureComponent);
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+    const hints = fixture.nativeElement.querySelector('[data-testid="keyboard-hints"]');
+    expect(hints).toBeTruthy();
+    expect(hints.textContent).toContain('Speichern');
+    expect(hints.textContent).toContain('Abbrechen');
+    expect(hints.textContent).toContain('Wechseln');
+  });
+
+  it('should not render anything when closed', () => {
+    const fixture = TestBed.createComponent(QuickCaptureComponent);
+    fixture.componentRef.setInput('open', false);
+    fixture.detectChanges();
+    const dialog = fixture.nativeElement.querySelector('[role="dialog"]');
+    expect(dialog).toBeNull();
+  });
+});

--- a/src/app/shared/quick-capture/quick-capture.ts
+++ b/src/app/shared/quick-capture/quick-capture.ts
@@ -70,6 +70,13 @@ type CaptureMode = 'todo' | 'idea';
               💡 Idee
             </button>
           </div>
+          <div
+            data-testid="keyboard-hints"
+            class="text-xs text-[var(--color-text-muted)] text-center mt-2"
+            aria-hidden="true"
+          >
+            ↵ Speichern · Esc Abbrechen · Tab Wechseln
+          </div>
         </div>
       </div>
     }

--- a/src/app/shared/workbench/workbench.html
+++ b/src/app/shared/workbench/workbench.html
@@ -26,7 +26,12 @@
             hier anzuzeigen.
           </p>
           <p class="text-sm text-[var(--color-text-muted)] mt-2">
-            Oder drücke <kbd class="px-1.5 py-0.5 rounded bg-[var(--color-bg-surface)] border border-[var(--color-border-subtle)] text-xs font-mono">{{ shortcutLabel }}</kbd> für Quick Capture
+            Oder drücke
+            <kbd
+              class="px-1.5 py-0.5 rounded bg-[var(--color-bg-surface)] border border-[var(--color-border-subtle)] text-xs font-mono"
+              >{{ shortcutLabel }}</kbd
+            >
+            für Quick Capture
           </p>
         </div>
       </div>

--- a/src/app/shared/workbench/workbench.html
+++ b/src/app/shared/workbench/workbench.html
@@ -25,6 +25,9 @@
             Wähle ein Ticket, einen Pull Request oder ein Todo aus der linken Spalte, um die Details
             hier anzuzeigen.
           </p>
+          <p class="text-sm text-[var(--color-text-muted)] mt-2">
+            Oder drücke <kbd class="px-1.5 py-0.5 rounded bg-[var(--color-bg-surface)] border border-[var(--color-border-subtle)] text-xs font-mono">{{ shortcutLabel }}</kbd> für Quick Capture
+          </p>
         </div>
       </div>
     }

--- a/src/app/shared/workbench/workbench.spec.ts
+++ b/src/app/shared/workbench/workbench.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { WorkbenchComponent } from './workbench';
+import { WorkspaceService } from '../workspace.service';
+import { signal } from '@angular/core';
+
+const mockMatchMedia = () => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+};
+
+describe('WorkbenchComponent', () => {
+  beforeEach(async () => {
+    mockMatchMedia();
+    await TestBed.configureTestingModule({
+      imports: [WorkbenchComponent],
+      providers: [
+        {
+          provide: WorkspaceService,
+          useValue: {
+            selectedItem: signal(null),
+            reflectionSelected: signal(false),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should show quick capture hint in empty state', () => {
+    const fixture = TestBed.createComponent(WorkbenchComponent);
+    fixture.detectChanges();
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Quick Capture');
+    expect(text).toMatch(/[⌘Ctrl]\+?K/);
+  });
+});

--- a/src/app/shared/workbench/workbench.ts
+++ b/src/app/shared/workbench/workbench.ts
@@ -21,6 +21,7 @@ import { ReflectionDetailComponent } from '../../reflection/reflection-detail/re
 })
 export class WorkbenchComponent {
   protected readonly data = inject(WorkspaceService);
+  protected readonly shortcutLabel = navigator.platform?.includes('Mac') ? '⌘K' : 'Ctrl+K';
 
   onReflectionSubmitted(): void {}
   onReflectionSkipped(): void {}


### PR DESCRIPTION
## Summary
- Keyboard-Hints im Quick Capture Modal: `↵ Speichern · Esc Abbrechen · Tab Wechseln`
- Sichtbarer Quick Capture Button in der Rail-Navigation (unter dem Logo, mit ⌘K/Ctrl+K Hint)
- Quick Capture Hinweis im Workbench Empty State ("Oder drücke ⌘K für Quick Capture")

## Test Plan
- [ ] Quick Capture Button in der Rail sichtbar, zeigt ⌘K / Ctrl+K
- [ ] Klick auf Button öffnet Quick Capture Modal
- [ ] Modal zeigt Keyboard-Hints unter den Toggle-Buttons
- [ ] Workbench Empty State (kein Item ausgewählt) zeigt Quick Capture Hint mit kbd-Styling
- [ ] Light und Dark Mode funktionieren korrekt
- [ ] Cmd+K / Ctrl+K Shortcut funktioniert weiterhin

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)